### PR TITLE
Update firewall-new-vpc-v3.0.template

### DIFF
--- a/cft with autoscale/security_stack/firewall-new-vpc-v3.0.template
+++ b/cft with autoscale/security_stack/firewall-new-vpc-v3.0.template
@@ -526,7 +526,7 @@
        "Condition" : "CreateSubnet3more",
        "Properties" : {
           "AllocationId" : { "Fn::GetAtt" : ["EIP3", "AllocationId"]},
-          "SubnetId" : { "Ref" : "NATGWSubnetAz1"}
+          "SubnetId" : { "Ref" : "NATGWSubnetAz3"}
        },
        "DependsOn" : [ "VPC", "EIP3", "NATGWSubnetAz3", "GatewayToInternet" ]
     },


### PR DESCRIPTION
## Description

Typo on the NATGW3 Resource was using NAT Subnet 1 not 3.

## Motivation and Context

It fixes a the NatGW for AZ 3.


## How Has This Been Tested?

I've run this stack to confirm that it's assigning out the correct AZ when it's being built.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->


- Bug fix (non-breaking change which fixes an issue)


